### PR TITLE
Require passing the `PYPI_TOKEN` secret when running publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,10 @@ on:
         default: "3.9"
         type: string
 
+    secrets:
+      PYPI_TOKEN:
+        required: true
+
 jobs:
   build-and-publish:
     name: Build and publish distributions to PyPI


### PR DESCRIPTION
Otherwise, the workflow fails to run when called from another repo: https://github.com/zigpy/zha-device-handlers/actions/runs/5730649731/job/15529866968