### PR TITLE
Add `--all-files` to pre-commit run command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Lint and static analysis
         run: |
           . venv/bin/activate
-          pre-commit run --show-diff-on-failure --color=always
+          pre-commit run --show-diff-on-failure --color=always --all-files
 
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds the `--all-files` parameter to the pre-commit run command.

Otherwise, pre-commit doesn't check any files and the check always runs successful, even if it shouldn't.
As an example, see: https://github.com/zigpy/zha-device-handlers/actions/runs/5771789313/job/15646109354?pr=2513

The pre-commit action that was used before https://github.com/zigpy/workflows/pull/5/ seems to always [run with `--all-files`](https://github.com/pre-commit/action/blob/5f528da5c95691c4cf42ff76a4d10854b62cbb82/action.yml#L7) (unless specified further).
Like the name implies, this will always run pre-commit on all files. (I think that behavior is wanted?)

Note: This change is **UNTESTED** as of right now.