### PR TITLE
Pin `actions/checkout` to `3.5.4`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Fetch all tags
+      run: git fetch --depth=1 --tags
     - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,9 +19,7 @@ jobs:
     name: Build and publish distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Fetch all tags
-      run: git fetch --depth=1 --tags
+    - uses: actions/checkout@v3.5.4
     - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
It looks like 3.6.0 introduced `fetch-tags`, which changed the default behavior. This breaks repo checkout and prevents `setuptools-git-versioning` from working properly, since no tags are checked out by default.