### PR TITLE
Use correct version for `actions/checkout`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and publish distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.4
+    - uses: actions/checkout@v3.5.3
     - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
`3.5.4` should be `3.5.3`.

As an aside, we really need to figure out a way to set up CI for the CI.