### PR TITLE
Set the fetch depth to `0` to disable shallow cloning

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,9 @@ jobs:
     name: Build and publish distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
#10 and #11 did not resolve the bellows cloning issue.