### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ on:
       CACHE_VERSION:
         description: Cache version
         required: false
-        default: 2
+        default: 3
         type: string
       PYTHON_VERSION_DEFAULT:
         description: Default Python version
         required: false
-        default: 3.9.15
+        default: 3.9.18
         type: string
       PRE_COMMIT_CACHE_PATH:
         description: Pre-commit cache path
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8.14', '3.9.15', '3.10.8', '3.11.0', '3.12']
+        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"]
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3
@@ -65,11 +65,12 @@ jobs:
           FROZENLIST_NO_EXTENSIONS: 1
           YARL_NO_EXTENSIONS: 1
         run: |
-          python -m venv venv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv venv
           . venv/bin/activate
-          pip install -U pip setuptools pre-commit
-          pip install -r requirements_test.txt
-          pip install -e .
+          uv pip install -U pip setuptools pre-commit
+          uv pip install -r requirements_test.txt
+          uv pip install -e .
       - name: Cache base Python virtual environment
         uses: actions/cache/save@v3
         with:
@@ -125,7 +126,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: ['3.8.14', '3.9.15', '3.10.8', '3.11.0', '3.12']
+        python-version: ["3.8.14", "3.9.15", "3.10.8", "3.11.0", "3.12"]
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: 80
         type: string
+      PYTHON_MATRIX:
+        description: 'Comma-separated list of Python versions e.g. "3.11","3.12"'
+        default: '"3.12"'
+        required: false
+        type: string
 
 jobs:
   # Separate job to pre-populate the base dependency cache
@@ -38,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"]
+        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX || '"3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"')) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3
@@ -126,7 +131,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"]
+        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX || '"3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"')) }}
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: ["3.8.14", "3.9.15", "3.10.8", "3.11.0", "3.12"]
+        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"]
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
       PYTHON_VERSION_DEFAULT:
         description: Default Python version
         required: false
-        default: 3.9.18
+        default: 3.9.15
         type: string
       PRE_COMMIT_CACHE_PATH:
         description: Pre-commit cache path
@@ -31,7 +31,7 @@ on:
         type: string
       PYTHON_MATRIX:
         description: 'Comma-separated list of Python versions e.g. "3.11","3.12"'
-        default: '"3.12"'
+        default: '"3.8.14", "3.9.15", "3.10.8", "3.11.0", "3.12"'
         required: false
         type: string
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX || '"3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"')) }}
+        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX)) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3
@@ -131,7 +131,7 @@ jobs:
     needs: prepare-base
     strategy:
       matrix:
-        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX || '"3.8.18", "3.9.18", "3.10.13", "3.11.8", "3.12"')) }}
+        python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX )) }}
     name: >-
       Run tests Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
This pull request includes changes to the Continuous Integration (CI) workflow file `.github/workflows/ci.yml`. The main changes involve updates to the Python version matrix, the switch from using the default Python environment to a custom one using `uv`, and an update to the cache version.

Here are the key changes in more detail:

Python version matrix and cache version:

* The default cache version was updated from `2` to `3`.
* A new input parameter `PYTHON_MATRIX` was added. This parameter is a comma-separated list of Python versions.
* The Python version matrix in the `strategy` section of the jobs was updated to use the `PYTHON_MATRIX` input parameter [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL41-R46) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL128-R134).

Switch to a custom Python environment:

* The `uv` tool was introduced to create a Python virtual environment and to install Python packages. This replaced the previous approach of using the default Python environment and the `pip` package manager.