### PR TITLE
Fail Codecov check on upload error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
This adds the `fail_ci_if_error` option to the Codecov action.
By default, the Codecov check succeeds, even if the upload fails. This makes the check fail if the upload fails.
Otherwise, the failing Codecov upload is easily missed.

We're now using codecov-action v4 (https://github.com/zigpy/workflows/pull/17) which should be "completely stable" for runs on the main repo where the `CODECOV_TOKEN` secret is available.
On PRs made from forks, we might still see rare failures, as those need to use tokenless uploads which are constrained by the GitHub API rate limit.

To notice those (rare) upload failures, we probably want to fail the Codecov upload check to make it clear that the upload failed. The codecov logs include an ETA of when tokenless uploads are available again. So, after 10 minutes or so, the upload job can then easily be restarted.