### PR TITLE
Update Codecov action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ on:
         required: false
         type: string
 
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
 jobs:
   # Separate job to pre-populate the base dependency cache
   # This prevent upcoming jobs to do the same individually
@@ -213,4 +217,6 @@ jobs:
           coverage report --fail-under=${{ inputs.MINIMUM_COVERAGE_PERCENTAGE }}
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Note

Please read the comment below this on how these PRs should be merged: https://github.com/zigpy/workflows/pull/17#issuecomment-2048796494
(TL;DR -> this PR first, then restart CI on linked PRs, then mark those as ready and merge when CI passes)

## Proposed change

Updates the Codecov action to v4.
This version now requires a Codecov token. This is provided as a different GitHub secret on each zigpy repo.
All individual workflows will need to be updated to pass the `CODECOV_TOKEN` secret to this shared workflow.

When a repo is forked, the GitHub secret will return an empty string. (Hopefully, still satisfying the `required` property in this shared workflow -- needs testing first). Codecov v4 detects that it's running on a fork and will use tokenless uploads, ignoring the empty token/secret. These tokenless updates can still hit the global GitHub API rate limit, but at least our repo commits won't.

There also seem to be some issues with v3 at the moment where it barely works at all. I'm not sure if they're related to the GH API rate limit or by some codecov issue, but v4 seems to work a lot better, even with tokenless uploads. (tested in HA repo)

### Corresponding PRs for all repos using the shared workflow:
- bellows: https://github.com/zigpy/bellows/pull/615
- zha-quirks: https://github.com/zigpy/zha-device-handlers/pull/3105
- zha: https://github.com/zigpy/zha/pull/46
- zigpy-deconz: https://github.com/zigpy/zigpy-deconz/pull/254
- zigpy-xbee: https://github.com/zigpy/zigpy-xbee/pull/175
- zigpy-zigate: https://github.com/zigpy/zigpy-zigate/pull/153
- zigpy-znp: https://github.com/zigpy/zigpy-znp/pull/245
- zigpy: https://github.com/zigpy/zigpy/pull/1380