### PR TITLE
Add `include-hidden-files` to upload-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage-${{ matrix.python-version }}
+          include-hidden-files: true
           path: .coverage
 
   coverage:


### PR DESCRIPTION
This should fix the issue of test coverage missing across the org. It's because of this breaking change: 
- https://github.com/actions/upload-artifact/issues/602

All workflow actions should be updated at a later point, too. It's on my list, but has to be tested. This is just to get CI going again.