### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
         type: string
       PYTHON_MATRIX:
         description: 'Comma-separated list of Python versions e.g. "3.11","3.12"'
-        default: '"3.8.14", "3.9.15", "3.10.8", "3.11.0", "3.12"'
+        default: '"3.9.15", "3.10.8", "3.11.0", "3.12"'
         required: false
         type: string
 


### PR DESCRIPTION
Zigpy no longer supports Python 3.8 so we can't test against it: <https://github.com/zigpy/zigpy/pull/1464>