### PR TITLE
Add Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
         type: string
       PYTHON_MATRIX:
         description: 'Comma-separated list of Python versions e.g. "3.11","3.12"'
-        default: '"3.9.15", "3.10.8", "3.11.0", "3.12"'
+        default: '"3.9.15", "3.10.8", "3.11.0", "3.12", "3.13"'
         required: false
         type: string
 


### PR DESCRIPTION
Python 3.13 was released last week!