### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,16 @@ jobs:
         python-version: ${{ fromJSON(format('[{0}]', inputs.PYTHON_MATRIX)) }}
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: venv
           key: >-
@@ -82,7 +82,7 @@ jobs:
           uv pip install -e .
       - name: Cache base Python virtual environment
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: venv
           key: ${{ steps.cache-venv.outputs.cache-primary-key }}
@@ -93,15 +93,15 @@ jobs:
     needs: prepare-base
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: python
         with:
           python-version: ${{ inputs.PYTHON_VERSION_DEFAULT }}
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: venv
@@ -111,7 +111,7 @@ jobs:
             hashFiles('setup.py', 'requirements_test.txt', 'requirements.txt', 'pyproject.toml', 'setup.cfg') }}
       - name: Restore pre-commit environment from cache
         id: cache-precommit
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ inputs.PRE_COMMIT_CACHE_PATH }}
           key: |
@@ -123,7 +123,7 @@ jobs:
           pre-commit install-hooks
       - name: Cache pre-commit environment
         if: steps.cache-precommit.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ${{ inputs.PRE_COMMIT_CACHE_PATH }}
           key: ${{ steps.cache-precommit.outputs.cache-primary-key }}
@@ -142,16 +142,16 @@ jobs:
       Run tests Python ${{ matrix.python-version }}
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: python
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: venv
@@ -184,7 +184,7 @@ jobs:
             -p no:sugar \
             tests
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.python-version }}
           include-hidden-files: true
@@ -196,16 +196,16 @@ jobs:
     needs: pytest
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: python
         with:
           python-version: ${{ inputs.PYTHON_VERSION_DEFAULT }}
           allow-prereleases: true
       - name: Restore base Python virtual environment
         id: cache-venv
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           fail-on-cache-miss: true
           path: venv
@@ -214,7 +214,7 @@ jobs:
             steps.python.outputs.python-version }}-${{
             hashFiles('setup.py', 'requirements_test.txt', 'requirements.txt', 'pyproject.toml', 'setup.cfg') }}
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Combine coverage results
         run: |
           . venv/bin/activate


### PR DESCRIPTION
This updates the following GitHub actions:
- update setup-python action from v4 to v5
- update checkout action from v3 to v4
- update cache action from v3 to v4
- update download-artifact action from v3 to v4

Most of these updates just switch to Node v20.
Updating the cache action also seems to fix our issues where saving cache took multiple minutes before. Now, it takes a couple of seconds.

Here's a test run on my zigpy fork: https://github.com/TheJulianJES/zigpy/actions/runs/11351227266
(The codecov test failure is expected there, as CI is not running in a PR. We might want to change that in the future, but that "issue" already exists at the moment.)