### PR TITLE
Update `setup-python` in PyPi release workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ inputs.PYTHON_VERSION_DEFAULT }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.PYTHON_VERSION_DEFAULT }}
     - name: Install wheel


### PR DESCRIPTION
Update `setup-python` action from v4 to v5 in the PyPi release workflow.
We've been using that version in our main CI workflow since https://github.com/zigpy/workflows/pull/24, so we should also upgrade it in the PyPi workflow.