### PR TITLE
Use exact versions in Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
         type: string
       PYTHON_MATRIX:
         description: 'Comma-separated list of Python versions e.g. "3.11","3.12"'
-        default: '"3.9.15", "3.10.8", "3.11.0", "3.12", "3.13"'
+        default: '"3.9.15", "3.10.8", "3.11.0", "3.12.9", "3.13.2"'
         required: false
         type: string
 


### PR DESCRIPTION
I'm noticing a lot of CI failures today that seem to stem from GitHub actions not using a consistent minor version:

```
# Set up Python 3.12
Run actions/setup-python@v5
Installed versions
  Successfully set up CPython (3.12.9)
                               ^^^^^^
...
# Restore base Python virtual environment
Error: Failed to restore cache entry. Exiting as fail-on-cache-miss is set.
Input key: 2-Linux-base-venv-3.12.10-52ed2b2b97441a5669110477fc580f538eeeab0617890c647a04f116296c1809
                             ^^^^^^^
```